### PR TITLE
feat: add npm-based auto-updater

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -5,8 +5,8 @@ go 1.25.0
 toolchain go1.25.5
 
 require (
-	github.com/atotto/clipboard v0.1.4
 	github.com/Masterminds/semver/v3 v3.4.0
+	github.com/atotto/clipboard v0.1.4
 	github.com/charmbracelet/bubbles v0.21.1-0.20250623103423-23b8fd6302d7
 	github.com/charmbracelet/bubbletea v1.3.6
 	github.com/charmbracelet/lipgloss v1.1.0

--- a/go.mod
+++ b/go.mod
@@ -6,6 +6,7 @@ toolchain go1.25.5
 
 require (
 	github.com/atotto/clipboard v0.1.4
+	github.com/Masterminds/semver/v3 v3.4.0
 	github.com/charmbracelet/bubbles v0.21.1-0.20250623103423-23b8fd6302d7
 	github.com/charmbracelet/bubbletea v1.3.6
 	github.com/charmbracelet/lipgloss v1.1.0
@@ -41,7 +42,6 @@ require (
 	github.com/Antonboom/testifylint v1.6.4 // indirect
 	github.com/BurntSushi/toml v1.5.0 // indirect
 	github.com/Djarvur/go-err113 v0.1.1 // indirect
-	github.com/Masterminds/semver/v3 v3.4.0 // indirect
 	github.com/MirrexOne/unqueryvet v1.3.0 // indirect
 	github.com/OpenPeeDeeP/depguard/v2 v2.2.1 // indirect
 	github.com/YuminosukeSato/lazygotest v0.4.1 // indirect

--- a/internal/tui/app/command_registry.go
+++ b/internal/tui/app/command_registry.go
@@ -55,6 +55,40 @@ func (m *Model) commandRegistry() (commandRegistry, error) {
 		shortcutQuit = keyLabel(m.keys.quit)
 	}
 
+	updateCommands := []commandSpec{
+		{
+			ID:      "update_check",
+			Label:   "Update: Check for updates",
+			Desc:    "Check npm for the latest version",
+			Aliases: []string{"check-updates", "updates check", "update check"},
+			Run: func(m *Model, _ commandArgs) tea.Cmd {
+				return m.handleUpdateCheck(updateCheckMsg{Force: true})
+			},
+		},
+	}
+	if m.updatePendingRestart {
+		updateCommands = append(updateCommands, commandSpec{
+			ID:      "update_restart",
+			Label:   "Update: Restart now",
+			Desc:    "Restart to finish installing the update",
+			Aliases: []string{"restart update", "update restart"},
+			Run: func(m *Model, _ commandArgs) tea.Cmd {
+				m.setState(StateUpdateRestart)
+				return nil
+			},
+		})
+	} else if m.updateState.UpdateAvailable() && !m.updateState.IsSkipped() {
+		updateCommands = append(updateCommands, commandSpec{
+			ID:      "update_open",
+			Label:   "Update: Install update",
+			Desc:    "Open the update dialog",
+			Aliases: []string{"update", "update install", "updates", "update dialog"},
+			Run: func(m *Model, _ commandArgs) tea.Cmd {
+				return m.openUpdateDialog()
+			},
+		})
+	}
+
 	groups := []commandGroup{
 		{
 			Name: "pane",
@@ -221,6 +255,10 @@ func (m *Model) commandRegistry() (commandRegistry, error) {
 					},
 				},
 			},
+		},
+		{
+			Name:     "updates",
+			Commands: updateCommands,
 		},
 		{
 			Name: "menu",

--- a/internal/tui/app/layout_metrics.go
+++ b/internal/tui/app/layout_metrics.go
@@ -34,6 +34,9 @@ func (m *Model) dashboardLayoutInternal(logCtx string) (dashboardLayout, bool) {
 	}
 
 	headerHeight := 1
+	if _, _, ok := m.updateBannerInfo(); ok {
+		headerHeight = 2
+	}
 	footerHeight := 1
 	quickReplyHeight := 3
 	headerGap := 1

--- a/internal/tui/app/model_dashboard.go
+++ b/internal/tui/app/model_dashboard.go
@@ -6,6 +6,13 @@ import (
 )
 
 func (m *Model) updateDashboard(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
+	if m.updatePromptPending {
+		m.updatePromptPending = false
+		return m, m.openUpdateDialog()
+	}
+	if cmd, handled := m.handleUpdateShortcut(msg); handled {
+		return m, cmd
+	}
 	if cmd, handled := m.handleDashboardFilter(msg); handled {
 		return m, cmd
 	}

--- a/internal/tui/app/model_lifecycle.go
+++ b/internal/tui/app/model_lifecycle.go
@@ -21,7 +21,7 @@ func (m *Model) SetAutoStart(spec AutoStartSpec) {
 }
 
 func (m *Model) Init() tea.Cmd {
-	cmds := []tea.Cmd{m.startRefreshCmd(), tickCmd(m.settings.RefreshInterval)}
+	cmds := []tea.Cmd{m.startRefreshCmd(), tickCmd(m.settings.RefreshInterval), m.scheduleUpdateInit()}
 	if m.client != nil {
 		cmds = append(cmds, waitDaemonEvent(m.client))
 	}

--- a/internal/tui/app/model_update.go
+++ b/internal/tui/app/model_update.go
@@ -90,6 +90,9 @@ var keyHandlers = map[ViewState]keyHandler{
 	StateRenameSession:    func(m *Model, msg tea.KeyMsg) (tea.Model, tea.Cmd) { return m.updateRename(msg) },
 	StateRenamePane:       func(m *Model, msg tea.KeyMsg) (tea.Model, tea.Cmd) { return m.updateRename(msg) },
 	StateProjectRootSetup: func(m *Model, msg tea.KeyMsg) (tea.Model, tea.Cmd) { return m.updateProjectRootSetup(msg) },
+	StateUpdateDialog:     func(m *Model, msg tea.KeyMsg) (tea.Model, tea.Cmd) { return m.updateUpdateDialog(msg) },
+	StateUpdateProgress:   func(m *Model, msg tea.KeyMsg) (tea.Model, tea.Cmd) { return m.updateUpdateProgress(msg) },
+	StateUpdateRestart:    func(m *Model, msg tea.KeyMsg) (tea.Model, tea.Cmd) { return m.updateUpdateRestart(msg) },
 }
 
 type updateHandler func(*Model, tea.Msg) (tea.Model, tea.Cmd)
@@ -98,6 +101,24 @@ var updateHandlers = map[reflect.Type]updateHandler{
 	reflect.TypeOf(tea.WindowSizeMsg{}): func(m *Model, msg tea.Msg) (tea.Model, tea.Cmd) {
 		m.applyWindowSize(msg.(tea.WindowSizeMsg))
 		return m, nil
+	},
+	reflect.TypeOf(updateCheckMsg{}): func(m *Model, msg tea.Msg) (tea.Model, tea.Cmd) {
+		return m, m.handleUpdateCheck(msg.(updateCheckMsg))
+	},
+	reflect.TypeOf(updateCheckResultMsg{}): func(m *Model, msg tea.Msg) (tea.Model, tea.Cmd) {
+		return m, m.handleUpdateCheckResult(msg.(updateCheckResultMsg))
+	},
+	reflect.TypeOf(updateTickMsg{}): func(m *Model, msg tea.Msg) (tea.Model, tea.Cmd) {
+		return m, m.handleUpdateTick()
+	},
+	reflect.TypeOf(updateProgressMsg{}): func(m *Model, msg tea.Msg) (tea.Model, tea.Cmd) {
+		return m, m.handleUpdateProgress(msg.(updateProgressMsg))
+	},
+	reflect.TypeOf(updateInstallResultMsg{}): func(m *Model, msg tea.Msg) (tea.Model, tea.Cmd) {
+		return m, m.handleUpdateInstallResult(msg.(updateInstallResultMsg))
+	},
+	reflect.TypeOf(updateRestartMsg{}): func(m *Model, msg tea.Msg) (tea.Model, tea.Cmd) {
+		return m, m.handleUpdateRestart(msg.(updateRestartMsg))
 	},
 	reflect.TypeOf(cursorShapeFlushMsg{}): func(m *Model, msg tea.Msg) (tea.Model, tea.Cmd) {
 		return m, m.handleCursorShapeFlush(msg.(cursorShapeFlushMsg))

--- a/internal/tui/app/mouse_hits.go
+++ b/internal/tui/app/mouse_hits.go
@@ -5,6 +5,8 @@ import (
 	"strings"
 	"time"
 
+	"github.com/charmbracelet/lipgloss"
+
 	"github.com/regenrek/peakypanes/internal/tui/mouse"
 	"github.com/regenrek/peakypanes/internal/tui/panelayout"
 )
@@ -91,6 +93,32 @@ func (m *Model) headerHitRects() []headerHitRect {
 			})
 		}
 		cursor = end
+	}
+	if label, hint, ok := m.updateBannerInfo(); ok {
+		text := label
+		if strings.TrimSpace(hint) != "" {
+			text = text + " " + hint
+		}
+		textWidth := lipgloss.Width(text)
+		if textWidth > 0 {
+			start := header.X + header.W - textWidth
+			if start < header.X {
+				start = header.X
+				textWidth = header.W
+			}
+			updateY := header.Y + 1
+			if updateY < header.Y+header.H {
+				hits = append(hits, headerHitRect{
+					Hit: mouse.HeaderHit{Kind: mouse.HeaderUpdate},
+					Rect: mouse.Rect{
+						X: start,
+						Y: updateY,
+						W: textWidth,
+						H: 1,
+					},
+				})
+			}
+		}
 	}
 	return hits
 }

--- a/internal/tui/app/mouse_integration.go
+++ b/internal/tui/app/mouse_integration.go
@@ -33,6 +33,7 @@ func (m *Model) updateDashboardMouse(msg tea.MouseMsg) (tea.Model, tea.Cmd) {
 		SelectDashboardTab:    m.selectDashboardTab,
 		SelectProjectTab:      m.selectProjectTab,
 		OpenProjectPicker:     m.openProjectPicker,
+		OpenUpdateDialog:      func() { _ = m.openUpdateDialog() },
 		SetTerminalFocus:      m.setTerminalFocus,
 		TerminalFocus:         func() bool { return m.terminalFocus },
 		SupportsTerminalFocus: m.supportsTerminalFocus,

--- a/internal/tui/app/types.go
+++ b/internal/tui/app/types.go
@@ -32,6 +32,9 @@ const (
 	StateSettingsMenu
 	StatePerformanceMenu
 	StateDebugMenu
+	StateUpdateDialog
+	StateUpdateProgress
+	StateUpdateRestart
 )
 
 // DashboardTab represents the active tab within the dashboard view.

--- a/internal/tui/app/update.go
+++ b/internal/tui/app/update.go
@@ -1,0 +1,396 @@
+package app
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"log/slog"
+	"os"
+	"os/exec"
+	"time"
+
+	tea "github.com/charmbracelet/bubbletea"
+
+	"github.com/regenrek/peakypanes/internal/sessiond"
+	"github.com/regenrek/peakypanes/internal/update"
+)
+
+const (
+	updateShortcutHint   = "Ctrl+Shift+U"
+	updateInitialDelay   = 2 * time.Second
+	updateInstallTimeout = 10 * time.Minute
+	updateRestartTimeout = 20 * time.Second
+)
+
+type updateProgress struct {
+	Step    string
+	Percent int
+	Err     error
+}
+
+type updateCheckMsg struct {
+	Force bool
+}
+
+type updateCheckResultMsg struct {
+	Latest    string
+	CheckedAt time.Time
+	Force     bool
+	Err       error
+}
+
+type updateTickMsg struct{}
+
+type updateProgressMsg struct {
+	Step    string
+	Percent int
+}
+
+type updateInstallResultMsg struct {
+	Err error
+}
+
+type updateRestartMsg struct {
+	Err error
+}
+
+func (m *Model) initUpdateState() {
+	m.updatePolicy = update.DefaultPolicy()
+	currentVersion := ""
+	if m.client != nil {
+		currentVersion = m.client.Version()
+	}
+	m.updateState = update.State{CurrentVersion: currentVersion}
+	exe, err := os.Executable()
+	if err == nil {
+		spec, specErr := update.DetectInstall(context.Background(), exe)
+		if specErr == nil {
+			m.updateSpec = spec
+			m.updateState.Channel = spec.Channel
+		}
+	}
+	statePath, err := update.DefaultStatePath()
+	if err != nil {
+		if !errors.Is(err, update.ErrStateDisabled) {
+			slog.Warn("update state path unavailable", "err", err)
+		}
+		m.updateClient = update.NPMClient{UserAgent: updateUserAgent(currentVersion)}
+		return
+	}
+	store := update.FileStore{Path: statePath}
+	loaded, err := store.Load(context.Background())
+	if err != nil {
+		slog.Warn("update state load failed", "err", err)
+	} else {
+		loaded.CurrentVersion = m.updateState.CurrentVersion
+		loaded.Channel = m.updateState.Channel
+		m.updateState = loaded
+	}
+	m.updateStore = store
+	m.updateClient = update.NPMClient{UserAgent: updateUserAgent(currentVersion)}
+}
+
+func updateUserAgent(version string) string {
+	v := update.NormalizeVersion(version)
+	if v == "" {
+		return "peakypanes/auto-update"
+	}
+	return fmt.Sprintf("peakypanes/%s", v)
+}
+
+func (m *Model) updateBannerInfo() (string, string, bool) {
+	if m.updatePendingRestart {
+		return "Restart to finish update", updateShortcutHint, true
+	}
+	if !m.updatePolicy.ShouldShowBanner(m.updateState) {
+		return "", "", false
+	}
+	latest := update.NormalizeVersion(m.updateState.LatestVersion)
+	label := "Update available"
+	if latest != "" {
+		label = fmt.Sprintf("Update available v%s", latest)
+	}
+	return label, updateShortcutHint, true
+}
+
+func (m *Model) updateDialogView() updateDialogView {
+	latest := update.NormalizeVersion(m.updateState.LatestVersion)
+	current := update.NormalizeVersion(m.updateState.CurrentVersion)
+	command := update.UpdateCommand(m.updateSpec)
+	return updateDialogView{
+		CurrentVersion: current,
+		LatestVersion:  latest,
+		Channel:        m.updateSpec.Channel,
+		Command:        command,
+		CanInstall:     m.updateSpec.Channel != update.ChannelUnknown,
+	}
+}
+
+func (m *Model) scheduleUpdateInit() tea.Cmd {
+	interval := m.updatePolicy.CheckInterval
+	if interval <= 0 {
+		interval = update.DefaultCheckInterval
+	}
+	return tea.Batch(
+		tea.Tick(updateInitialDelay, func(time.Time) tea.Msg { return updateCheckMsg{Force: false} }),
+		tea.Tick(interval, func(time.Time) tea.Msg { return updateTickMsg{} }),
+	)
+}
+
+func (m *Model) handleUpdateCheck(msg updateCheckMsg) tea.Cmd {
+	if m.updateCheckInFlight {
+		return nil
+	}
+	now := time.Now()
+	if !msg.Force && !m.updatePolicy.ShouldCheck(m.updateState.LastCheckUnixMs, now) {
+		return nil
+	}
+	m.updateCheckInFlight = true
+	return m.updateCheckCmd(msg.Force)
+}
+
+func (m *Model) handleUpdateTick() tea.Cmd {
+	interval := m.updatePolicy.CheckInterval
+	if interval <= 0 {
+		interval = update.DefaultCheckInterval
+	}
+	cmd := tea.Tick(interval, func(time.Time) tea.Msg { return updateTickMsg{} })
+	return tea.Batch(cmd, m.handleUpdateCheck(updateCheckMsg{Force: false}))
+}
+
+func (m *Model) updateCheckCmd(force bool) tea.Cmd {
+	client := m.updateClient
+	return func() tea.Msg {
+		if client == nil {
+			return updateCheckResultMsg{Err: errors.New("update client unavailable"), Force: force, CheckedAt: time.Now()}
+		}
+		ctx, cancel := context.WithTimeout(context.Background(), 15*time.Second)
+		defer cancel()
+		latest, err := client.LatestVersion(ctx)
+		return updateCheckResultMsg{Latest: latest, Err: err, Force: force, CheckedAt: time.Now()}
+	}
+}
+
+func (m *Model) handleUpdateCheckResult(msg updateCheckResultMsg) tea.Cmd {
+	m.updateCheckInFlight = false
+	if msg.Err != nil {
+		if msg.Force {
+			m.setToast("Update check failed: "+msg.Err.Error(), toastError)
+		}
+		return nil
+	}
+	m.updateState.LatestVersion = msg.Latest
+	m.updateState.MarkChecked(msg.CheckedAt)
+	if m.updateStore != nil {
+		saveUpdateState(m.updateStore, m.updateState)
+	}
+	if msg.Force {
+		if !m.updateState.UpdateAvailable() {
+			m.setToast("PeakyPanes is up to date", toastSuccess)
+		} else if m.updateState.IsSkipped() {
+			m.setToast("Latest update is skipped", toastInfo)
+		} else {
+			return m.openUpdateDialog()
+		}
+	}
+	if m.updatePolicy.ShouldPrompt(m.updateState, msg.CheckedAt) {
+		return m.promptUpdateIfReady()
+	}
+	return nil
+}
+
+func saveUpdateState(store update.Store, state update.State) {
+	if store == nil {
+		return
+	}
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+	defer cancel()
+	if err := store.Save(ctx, state); err != nil {
+		slog.Warn("update state save failed", "err", err)
+	}
+}
+
+func (m *Model) promptUpdateIfReady() tea.Cmd {
+	if m.state == StateDashboard {
+		return m.openUpdateDialog()
+	}
+	m.updatePromptPending = true
+	return nil
+}
+
+func (m *Model) openUpdateDialog() tea.Cmd {
+	if m.updatePendingRestart {
+		m.setState(StateUpdateRestart)
+		return nil
+	}
+	if !m.updateState.UpdateAvailable() || m.updateState.IsSkipped() {
+		return nil
+	}
+	m.setState(StateUpdateDialog)
+	return nil
+}
+
+func (m *Model) handleUpdateShortcut(msg tea.KeyMsg) (tea.Cmd, bool) {
+	if msg.String() != "ctrl+shift+u" {
+		return nil, false
+	}
+	return m.openUpdateDialog(), true
+}
+
+func (m *Model) updateUpdateDialog(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
+	switch msg.String() {
+	case "i", "enter":
+		return m, m.startUpdateInstall()
+	case "l":
+		m.markUpdatePrompted()
+		m.setState(StateDashboard)
+		return m, nil
+	case "s":
+		m.updateState.SkippedVersion = m.updateState.LatestVersion
+		m.markUpdatePrompted()
+		m.setState(StateDashboard)
+		return m, nil
+	case "esc":
+		m.markUpdatePrompted()
+		m.setState(StateDashboard)
+		return m, nil
+	default:
+		return m, nil
+	}
+}
+
+func (m *Model) markUpdatePrompted() {
+	m.updateState.MarkPrompted(time.Now())
+	if m.updateStore != nil {
+		saveUpdateState(m.updateStore, m.updateState)
+	}
+}
+
+func (m *Model) startUpdateInstall() tea.Cmd {
+	if m.updateSpec.Channel == update.ChannelUnknown {
+		m.setToast("Automatic updates unavailable for this install", toastInfo)
+		return nil
+	}
+	m.updateState.SkippedVersion = ""
+	m.markUpdatePrompted()
+	m.updateProgress = updateProgress{Step: "Preparing", Percent: 5}
+	m.updateRunCh = startUpdateRun(m.updateSpec)
+	m.setState(StateUpdateProgress)
+	return waitUpdateRunMsg(m.updateRunCh)
+}
+
+func startUpdateRun(spec update.InstallSpec) <-chan tea.Msg {
+	ch := make(chan tea.Msg, 4)
+	go func() {
+		defer close(ch)
+		ch <- updateProgressMsg{Step: "Installing", Percent: 20}
+		installer := update.NewInstaller()
+		ctx, cancel := context.WithTimeout(context.Background(), updateInstallTimeout)
+		defer cancel()
+		err := installer.Install(ctx, spec)
+		if err != nil {
+			ch <- updateInstallResultMsg{Err: err}
+			return
+		}
+		ch <- updateProgressMsg{Step: "Update installed", Percent: 100}
+		ch <- updateInstallResultMsg{}
+	}()
+	return ch
+}
+
+func waitUpdateRunMsg(ch <-chan tea.Msg) tea.Cmd {
+	if ch == nil {
+		return nil
+	}
+	return func() tea.Msg {
+		msg, ok := <-ch
+		if !ok {
+			return nil
+		}
+		return msg
+	}
+}
+
+func (m *Model) handleUpdateProgress(msg updateProgressMsg) tea.Cmd {
+	m.updateProgress.Step = msg.Step
+	m.updateProgress.Percent = msg.Percent
+	return waitUpdateRunMsg(m.updateRunCh)
+}
+
+func (m *Model) handleUpdateInstallResult(msg updateInstallResultMsg) tea.Cmd {
+	m.updateRunCh = nil
+	if msg.Err != nil {
+		m.setToast("Update failed: "+msg.Err.Error(), toastError)
+		m.setState(StateUpdateDialog)
+		return nil
+	}
+	m.updatePendingRestart = true
+	m.setState(StateUpdateRestart)
+	return nil
+}
+
+func (m *Model) updateUpdateProgress(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
+	return m, nil
+}
+
+func (m *Model) updateUpdateRestart(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
+	switch msg.String() {
+	case "r", "enter":
+		return m, m.restartAfterUpdateCmd()
+	case "esc":
+		m.setState(StateDashboard)
+		return m, nil
+	default:
+		return m, nil
+	}
+}
+
+func (m *Model) restartAfterUpdateCmd() tea.Cmd {
+	current := ""
+	if m.client != nil {
+		current = m.client.Version()
+	}
+	return func() tea.Msg {
+		ctx, cancel := context.WithTimeout(context.Background(), updateRestartTimeout)
+		defer cancel()
+		if current != "" {
+			if err := sessiond.RestartDaemon(ctx, current); err != nil {
+				return updateRestartMsg{Err: err}
+			}
+		}
+		exe, err := os.Executable()
+		if err != nil {
+			return updateRestartMsg{Err: err}
+		}
+		cmd := exec.Command(exe, os.Args[1:]...)
+		cmd.Env = os.Environ()
+		cmd.Stdout = os.Stdout
+		cmd.Stderr = os.Stderr
+		cmd.Stdin = os.Stdin
+		if err := cmd.Start(); err != nil {
+			return updateRestartMsg{Err: err}
+		}
+		return updateRestartMsg{}
+	}
+}
+
+func (m *Model) handleUpdateRestart(msg updateRestartMsg) tea.Cmd {
+	if msg.Err != nil {
+		m.setToast("Restart failed: "+msg.Err.Error(), toastError)
+		return nil
+	}
+	m.updatePendingRestart = false
+	m.updateState.MarkPrompted(time.Now())
+	if m.updateStore != nil {
+		saveUpdateState(m.updateStore, m.updateState)
+	}
+	return tea.Sequence(m.shutdownCmd(), tea.Quit)
+}
+
+type updateDialogView struct {
+	CurrentVersion string
+	LatestVersion  string
+	Channel        update.Channel
+	Command        string
+	CanInstall     bool
+}

--- a/internal/tui/app/update_dialog_test.go
+++ b/internal/tui/app/update_dialog_test.go
@@ -1,0 +1,52 @@
+package app
+
+import (
+	"testing"
+
+	tea "github.com/charmbracelet/bubbletea"
+
+	"github.com/regenrek/peakypanes/internal/update"
+)
+
+func TestUpdateDialogLaterMarksPrompt(t *testing.T) {
+	m := newTestModelLite()
+	m.updatePolicy = update.DefaultPolicy()
+	m.updateState = update.State{CurrentVersion: "1.0.0", LatestVersion: "1.1.0"}
+	m.openUpdateDialog()
+	if m.state != StateUpdateDialog {
+		t.Fatalf("expected update dialog state")
+	}
+	m.updateUpdateDialog(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'l'}})
+	if m.state != StateDashboard {
+		t.Fatalf("expected dashboard after later")
+	}
+	if m.updateState.LastPromptUnixMs == 0 {
+		t.Fatalf("expected last prompt set")
+	}
+}
+
+func TestUpdateDialogSkipSetsVersion(t *testing.T) {
+	m := newTestModelLite()
+	m.updatePolicy = update.DefaultPolicy()
+	m.updateState = update.State{CurrentVersion: "1.0.0", LatestVersion: "1.2.0"}
+	m.openUpdateDialog()
+	m.updateUpdateDialog(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'s'}})
+	if m.updateState.SkippedVersion != "1.2.0" {
+		t.Fatalf("expected skipped version set")
+	}
+}
+
+func TestUpdateBannerInfo(t *testing.T) {
+	m := newTestModelLite()
+	m.updatePolicy = update.DefaultPolicy()
+	m.updateState = update.State{CurrentVersion: "1.0.0", LatestVersion: "1.1.0"}
+	label, hint, ok := m.updateBannerInfo()
+	if !ok || label == "" || hint == "" {
+		t.Fatalf("expected banner info")
+	}
+	m.updatePendingRestart = true
+	label, _, ok = m.updateBannerInfo()
+	if !ok || label == "" {
+		t.Fatalf("expected restart banner info")
+	}
+}

--- a/internal/tui/app/view_model.go
+++ b/internal/tui/app/view_model.go
@@ -25,6 +25,9 @@ func (m *Model) viewModel() views.Model {
 		previewSession = session
 	}
 
+	bannerLabel, bannerHint, bannerVisible := m.updateBannerInfo()
+	updateDialog := m.updateDialogView()
+
 	vm := views.Model{
 		Width:                    m.width,
 		Height:                   m.height,
@@ -93,6 +96,22 @@ func (m *Model) viewModel() views.Model {
 		DashboardPreviewLines: dashboardPreviewLines(m.settings),
 		PaneView:              m.paneViewProvider(),
 		DialogHelp:            m.dialogHelpView(),
+		UpdateBanner: views.UpdateBanner{
+			Visible: bannerVisible,
+			Label:   bannerLabel,
+			Hint:    bannerHint,
+		},
+		UpdateDialog: views.UpdateDialog{
+			CurrentVersion: updateDialog.CurrentVersion,
+			LatestVersion:  updateDialog.LatestVersion,
+			Channel:        string(updateDialog.Channel),
+			Command:        updateDialog.Command,
+			CanInstall:     updateDialog.CanInstall,
+		},
+		UpdateProgress: views.UpdateProgress{
+			Step:    m.updateProgress.Step,
+			Percent: m.updateProgress.Percent,
+		},
 	}
 
 	return vm

--- a/internal/tui/mouse/filter.go
+++ b/internal/tui/mouse/filter.go
@@ -43,6 +43,7 @@ const (
 	HeaderDashboard HeaderKind = iota
 	HeaderProject
 	HeaderNew
+	HeaderUpdate
 )
 
 // HeaderHit captures a header hit-test match.

--- a/internal/tui/mouse/handler.go
+++ b/internal/tui/mouse/handler.go
@@ -26,6 +26,7 @@ type DashboardCallbacks struct {
 	SelectDashboardTab    func() bool
 	SelectProjectTab      func(projectID string) bool
 	OpenProjectPicker     func()
+	OpenUpdateDialog      func()
 	SetTerminalFocus      func(focus bool)
 	TerminalFocus         func() bool
 	SupportsTerminalFocus func() bool
@@ -92,6 +93,11 @@ func (h *Handler) handleHeaderClick(msg tea.MouseMsg, cb DashboardCallbacks) (te
 	case HeaderNew:
 		if cb.OpenProjectPicker != nil {
 			cb.OpenProjectPicker()
+		}
+		return nil, true
+	case HeaderUpdate:
+		if cb.OpenUpdateDialog != nil {
+			cb.OpenUpdateDialog()
 		}
 		return nil, true
 	default:

--- a/internal/tui/theme/theme.go
+++ b/internal/tui/theme/theme.go
@@ -219,6 +219,15 @@ var ShortcutNote = lipgloss.NewStyle().
 var ShortcutHint = lipgloss.NewStyle().
 	Foreground(TextDim)
 
+// UpdateBanner highlights update availability in the header.
+var UpdateBanner = lipgloss.NewStyle().
+	Bold(true).
+	Foreground(Warning)
+
+// UpdateBannerHint styles the update shortcut hint.
+var UpdateBannerHint = lipgloss.NewStyle().
+	Foreground(TextMuted)
+
 // ===== Tabs and Sections =====
 
 // TabActive for active tabs (projects/views).

--- a/internal/tui/views/constants.go
+++ b/internal/tui/views/constants.go
@@ -21,6 +21,9 @@ const (
 	viewSettingsMenu
 	viewPerformanceMenu
 	viewDebugMenu
+	viewUpdateDialog
+	viewUpdateProgress
+	viewUpdateRestart
 )
 
 // Tab ordering must match app.DashboardTab.

--- a/internal/tui/views/model.go
+++ b/internal/tui/views/model.go
@@ -54,6 +54,9 @@ type Model struct {
 	DashboardPreviewLines    int
 	PaneView                 func(id string, width, height int, showCursor bool, useLipgloss bool) string
 	DialogHelp               DialogHelp
+	UpdateBanner             UpdateBanner
+	UpdateDialog             UpdateDialog
+	UpdateProgress           UpdateProgress
 }
 
 type Project struct {
@@ -67,6 +70,25 @@ type DialogHelp struct {
 	Title string
 	Body  string
 	Open  bool
+}
+
+type UpdateBanner struct {
+	Visible bool
+	Label   string
+	Hint    string
+}
+
+type UpdateDialog struct {
+	CurrentVersion string
+	LatestVersion  string
+	Channel        string
+	Command        string
+	CanInstall     bool
+}
+
+type UpdateProgress struct {
+	Step    string
+	Percent int
 }
 
 type Session struct {

--- a/internal/tui/views/render.go
+++ b/internal/tui/views/render.go
@@ -28,4 +28,7 @@ var viewRenderers = map[int]func(Model) string{
 	viewRenameSession:           func(m Model) string { return m.viewRename() },
 	viewRenamePane:              func(m Model) string { return m.viewRename() },
 	viewProjectRootSetup:        func(m Model) string { return m.viewProjectRootSetup() },
+	viewUpdateDialog:            func(m Model) string { return m.viewUpdateDialog() },
+	viewUpdateProgress:          func(m Model) string { return m.viewUpdateProgress() },
+	viewUpdateRestart:           func(m Model) string { return m.viewUpdateRestart() },
 }

--- a/internal/tui/views/render_dashboard.go
+++ b/internal/tui/views/render_dashboard.go
@@ -74,7 +74,16 @@ func (m Model) viewHeader(width int) string {
 	if spaces < 1 {
 		return fitLine(left, width)
 	}
-	return left + strings.Repeat(" ", spaces) + right
+	firstLine := left + strings.Repeat(" ", spaces) + right
+	if !m.UpdateBanner.Visible {
+		return firstLine
+	}
+	bannerText := theme.UpdateBanner.Render(m.UpdateBanner.Label)
+	if strings.TrimSpace(m.UpdateBanner.Hint) != "" {
+		bannerText += theme.UpdateBannerHint.Render(" " + m.UpdateBanner.Hint)
+	}
+	secondLine := rightAlignLine(bannerText, width)
+	return firstLine + "\n" + fitLine(secondLine, width)
 }
 
 func (m Model) viewBody(width, height int) string {

--- a/internal/tui/views/render_helpers.go
+++ b/internal/tui/views/render_helpers.go
@@ -132,6 +132,18 @@ func centerLine(text string, width int) string {
 	return strings.Repeat(" ", leftPad) + text + strings.Repeat(" ", rightPad)
 }
 
+func rightAlignLine(text string, width int) string {
+	if width <= 0 {
+		return ""
+	}
+	lineWidth := lipgloss.Width(text)
+	if lineWidth >= width {
+		return ansi.Truncate(text, width, "")
+	}
+	pad := width - lineWidth
+	return strings.Repeat(" ", pad) + text
+}
+
 func truncateRunes(text string, width int) string {
 	if width <= 0 {
 		return ""

--- a/internal/tui/views/render_updates.go
+++ b/internal/tui/views/render_updates.go
@@ -1,0 +1,128 @@
+package views
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/regenrek/peakypanes/internal/tui/theme"
+)
+
+func (m Model) viewUpdateDialog() string {
+	dlg := m.UpdateDialog
+	body := strings.Builder{}
+	if dlg.CurrentVersion != "" {
+		body.WriteString(theme.DialogLabel.Render("Current: "))
+		body.WriteString(theme.DialogValue.Render(fmt.Sprintf("v%s", dlg.CurrentVersion)))
+		body.WriteString("\n")
+	}
+	if dlg.LatestVersion != "" {
+		body.WriteString(theme.DialogLabel.Render("Latest:  "))
+		body.WriteString(theme.DialogValue.Render(fmt.Sprintf("v%s", dlg.LatestVersion)))
+		body.WriteString("\n")
+	}
+	if strings.TrimSpace(dlg.Channel) != "" {
+		body.WriteString(theme.DialogLabel.Render("Channel: "))
+		body.WriteString(theme.DialogValue.Render(formatUpdateChannel(dlg.Channel)))
+		body.WriteString("\n")
+	}
+	if dlg.Command != "" && dlg.Command != "Update manually" {
+		body.WriteString(theme.DialogNote.Render("Command: "))
+		body.WriteString(theme.DialogValue.Render(dlg.Command))
+		body.WriteString("\n")
+	}
+	if !dlg.CanInstall {
+		body.WriteString(theme.DialogNote.Render("Automatic updates are unavailable for this install."))
+		body.WriteString("\n")
+	}
+	choices := []dialogChoice{
+		{Key: "l", Label: "Later"},
+		{Key: "s", Label: "Skip this version"},
+		{Key: "esc", Label: "Close"},
+	}
+	if dlg.CanInstall {
+		choices = append([]dialogChoice{{Key: "i", Label: "Install now"}}, choices...)
+	}
+	content := dialogContent(
+		dialogTitleStyle.Render("Update Available"),
+		body.String(),
+		renderDialogChoices(choices),
+	)
+	return m.renderDialog(dialogSpec{Content: content})
+}
+
+func (m Model) viewUpdateProgress() string {
+	progress := m.UpdateProgress
+	bar := renderProgressBar(28, progress.Percent)
+	body := strings.Builder{}
+	if progress.Step != "" {
+		body.WriteString(theme.DialogLabel.Render("Step: "))
+		body.WriteString(theme.DialogValue.Render(progress.Step))
+		body.WriteString("\n")
+	}
+	body.WriteString(theme.DialogValue.Render(bar))
+	body.WriteString("\n")
+	body.WriteString(theme.DialogNote.Render(fmt.Sprintf("%d%%", clampPercent(progress.Percent))))
+	content := dialogContent(
+		dialogTitleStyle.Render("Installing Update"),
+		body.String(),
+	)
+	return m.renderDialog(dialogSpec{Content: content})
+}
+
+func (m Model) viewUpdateRestart() string {
+	body := theme.DialogNote.Render("Update installed. Restart to finish.")
+	choices := renderDialogChoices([]dialogChoice{
+		{Key: "r", Label: "Restart now"},
+		{Key: "esc", Label: "Later"},
+	})
+	content := dialogContent(
+		dialogTitleStyle.Render("Restart Required"),
+		body,
+		choices,
+	)
+	return m.renderDialog(dialogSpec{Content: content})
+}
+
+func formatUpdateChannel(value string) string {
+	trimmed := strings.TrimSpace(value)
+	if trimmed == "" {
+		return "-"
+	}
+	switch trimmed {
+	case "npm_global":
+		return "npm (global)"
+	case "npm_local":
+		return "npm (local)"
+	case "homebrew":
+		return "homebrew"
+	case "git":
+		return "git"
+	default:
+		return trimmed
+	}
+}
+
+func renderProgressBar(width int, percent int) string {
+	if width < 10 {
+		width = 10
+	}
+	p := clampPercent(percent)
+	fill := width * p / 100
+	if fill < 0 {
+		fill = 0
+	}
+	if fill > width {
+		fill = width
+	}
+	return "[" + strings.Repeat("=", fill) + strings.Repeat("-", width-fill) + "]"
+}
+
+func clampPercent(value int) int {
+	if value < 0 {
+		return 0
+	}
+	if value > 100 {
+		return 100
+	}
+	return value
+}

--- a/internal/update/channel.go
+++ b/internal/update/channel.go
@@ -1,0 +1,113 @@
+package update
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+)
+
+// Channel identifies the install/update channel.
+type Channel string
+
+const (
+	ChannelUnknown   Channel = "unknown"
+	ChannelNPMGlobal Channel = "npm_global"
+	ChannelNPMLocal  Channel = "npm_local"
+	ChannelHomebrew  Channel = "homebrew"
+	ChannelGit       Channel = "git"
+)
+
+// InstallSpec captures channel-specific install metadata.
+type InstallSpec struct {
+	Channel    Channel
+	Executable string
+	NPMRoot    string
+	GitRoot    string
+}
+
+// DetectInstall inspects the executable path to determine the install channel.
+func DetectInstall(ctx context.Context, exePath string) (InstallSpec, error) {
+	if ctx == nil {
+		ctx = context.Background()
+	}
+	if err := ctx.Err(); err != nil {
+		return InstallSpec{}, err
+	}
+	path := strings.TrimSpace(exePath)
+	if path == "" {
+		return InstallSpec{Channel: ChannelUnknown}, fmt.Errorf("executable path empty")
+	}
+	resolved, err := filepath.EvalSymlinks(path)
+	if err != nil {
+		resolved = path
+	}
+	resolved = filepath.Clean(resolved)
+	slash := filepath.ToSlash(resolved)
+	if isHomebrewPath(slash) {
+		return InstallSpec{Channel: ChannelHomebrew, Executable: resolved}, nil
+	}
+	npmChannel, npmRoot := detectNPMChannel(slash)
+	if npmChannel != ChannelUnknown {
+		return InstallSpec{Channel: npmChannel, Executable: resolved, NPMRoot: npmRoot}, nil
+	}
+	gitRoot, ok := findGitRoot(ctx, filepath.Dir(resolved))
+	if ok {
+		return InstallSpec{Channel: ChannelGit, Executable: resolved, GitRoot: gitRoot}, nil
+	}
+	return InstallSpec{Channel: ChannelUnknown, Executable: resolved}, nil
+}
+
+func isHomebrewPath(path string) bool {
+	return strings.Contains(path, "/Cellar/peakypanes/") || strings.Contains(path, "/Homebrew/Cellar/peakypanes/")
+}
+
+func detectNPMChannel(path string) (Channel, string) {
+	idx := strings.LastIndex(path, "/node_modules/")
+	if idx == -1 {
+		return ChannelUnknown, ""
+	}
+	root := filepath.FromSlash(path[:idx])
+	if strings.Contains(path, "/lib/node_modules/") {
+		return ChannelNPMGlobal, root
+	}
+	return ChannelNPMLocal, root
+}
+
+func findGitRoot(ctx context.Context, start string) (string, bool) {
+	path := filepath.Clean(start)
+	for {
+		if err := ctx.Err(); err != nil {
+			return "", false
+		}
+		gitPath := filepath.Join(path, ".git")
+		if info, err := os.Stat(gitPath); err == nil {
+			if info.IsDir() || info.Mode().IsRegular() {
+				return path, true
+			}
+		}
+		parent := filepath.Dir(path)
+		if parent == path {
+			break
+		}
+		path = parent
+	}
+	return "", false
+}
+
+// UpdateCommand returns a human-readable update command for the channel.
+func UpdateCommand(spec InstallSpec) string {
+	switch spec.Channel {
+	case ChannelHomebrew:
+		return "brew upgrade peakypanes"
+	case ChannelNPMGlobal:
+		return "npm update -g peakypanes"
+	case ChannelNPMLocal:
+		return "npm update peakypanes"
+	case ChannelGit:
+		return "git pull --ff-only && go install ./cmd/peakypanes ./cmd/peky"
+	default:
+		return "Update manually"
+	}
+}

--- a/internal/update/install.go
+++ b/internal/update/install.go
@@ -1,0 +1,95 @@
+package update
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+)
+
+// Installer runs channel-specific update commands.
+type Installer struct {
+	execCommand func(context.Context, string, ...string) *exec.Cmd
+}
+
+// NewInstaller builds a default installer.
+func NewInstaller() Installer {
+	return Installer{execCommand: exec.CommandContext}
+}
+
+// Install updates PeakyPanes using the detected channel.
+func (i Installer) Install(ctx context.Context, spec InstallSpec) error {
+	if ctx == nil {
+		ctx = context.Background()
+	}
+	if err := ctx.Err(); err != nil {
+		return err
+	}
+	execCommand := i.execCommand
+	if execCommand == nil {
+		execCommand = exec.CommandContext
+	}
+	switch spec.Channel {
+	case ChannelHomebrew:
+		return runCommand(ctx, execCommand, "", "brew", "upgrade", "peakypanes")
+	case ChannelNPMGlobal:
+		return runCommand(ctx, execCommand, "", "npm", "update", "-g", "peakypanes")
+	case ChannelNPMLocal:
+		root, err := cleanRoot(spec.NPMRoot)
+		if err != nil {
+			return err
+		}
+		return runCommand(ctx, execCommand, root, "npm", "update", "peakypanes")
+	case ChannelGit:
+		root, err := cleanRoot(spec.GitRoot)
+		if err != nil {
+			return err
+		}
+		if err := runCommand(ctx, execCommand, root, "git", "pull", "--ff-only"); err != nil {
+			return err
+		}
+		return runCommand(ctx, execCommand, root, "go", "install", "./cmd/peakypanes", "./cmd/peky")
+	default:
+		return fmt.Errorf("unsupported update channel: %s", spec.Channel)
+	}
+}
+
+func cleanRoot(root string) (string, error) {
+	trimmed := strings.TrimSpace(root)
+	if trimmed == "" {
+		return "", fmt.Errorf("update root is empty")
+	}
+	cleaned := filepath.Clean(trimmed)
+	if !filepath.IsAbs(cleaned) {
+		return "", fmt.Errorf("update root must be absolute")
+	}
+	info, err := os.Stat(cleaned)
+	if err != nil {
+		return "", fmt.Errorf("update root unavailable: %w", err)
+	}
+	if !info.IsDir() {
+		return "", fmt.Errorf("update root is not a directory")
+	}
+	return cleaned, nil
+}
+
+func runCommand(ctx context.Context, execCommand func(context.Context, string, ...string) *exec.Cmd, dir string, name string, args ...string) error {
+	if ctx == nil {
+		ctx = context.Background()
+	}
+	cmd := execCommand(ctx, name, args...)
+	if dir != "" {
+		cmd.Dir = dir
+	}
+	output, err := cmd.CombinedOutput()
+	if err != nil {
+		trimmed := strings.TrimSpace(string(output))
+		if trimmed == "" {
+			return fmt.Errorf("update command failed: %w", err)
+		}
+		return fmt.Errorf("update command failed: %w: %s", err, trimmed)
+	}
+	return nil
+}

--- a/internal/update/npm.go
+++ b/internal/update/npm.go
@@ -1,0 +1,68 @@
+package update
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"strings"
+	"time"
+)
+
+const npmLatestURL = "https://registry.npmjs.org/peakypanes/latest"
+
+// RegistryClient retrieves the latest version.
+type RegistryClient interface {
+	LatestVersion(ctx context.Context) (string, error)
+}
+
+// NPMClient fetches versions from the npm registry.
+type NPMClient struct {
+	HTTPClient *http.Client
+	UserAgent  string
+}
+
+type npmLatestResponse struct {
+	Version string `json:"version"`
+}
+
+// LatestVersion implements RegistryClient.
+func (c NPMClient) LatestVersion(ctx context.Context) (version string, err error) {
+	if ctx == nil {
+		ctx = context.Background()
+	}
+	client := c.HTTPClient
+	if client == nil {
+		client = &http.Client{Timeout: 15 * time.Second}
+	}
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, npmLatestURL, nil)
+	if err != nil {
+		return "", fmt.Errorf("npm request: %w", err)
+	}
+	ua := c.UserAgent
+	if ua == "" {
+		ua = "peakypanes/auto-update"
+	}
+	req.Header.Set("User-Agent", ua)
+	req.Header.Set("Accept", "application/json")
+	resp, err := client.Do(req)
+	if err != nil {
+		return "", fmt.Errorf("npm request: %w", err)
+	}
+	defer func() {
+		if cerr := resp.Body.Close(); cerr != nil && err == nil {
+			err = fmt.Errorf("npm close response: %w", cerr)
+		}
+	}()
+	if resp.StatusCode != http.StatusOK {
+		return "", fmt.Errorf("npm status %d", resp.StatusCode)
+	}
+	var payload npmLatestResponse
+	if err := json.NewDecoder(resp.Body).Decode(&payload); err != nil {
+		return "", fmt.Errorf("npm decode: %w", err)
+	}
+	if strings.TrimSpace(payload.Version) == "" {
+		return "", fmt.Errorf("npm response missing version")
+	}
+	return payload.Version, nil
+}

--- a/internal/update/policy.go
+++ b/internal/update/policy.go
@@ -1,0 +1,59 @@
+package update
+
+import "time"
+
+const (
+	DefaultPromptCooldown = 72 * time.Hour
+	DefaultCheckInterval  = 24 * time.Hour
+)
+
+// Policy defines update prompt behavior.
+type Policy struct {
+	PromptCooldown time.Duration
+	CheckInterval  time.Duration
+}
+
+// DefaultPolicy returns the default update policy.
+func DefaultPolicy() Policy {
+	return Policy{PromptCooldown: DefaultPromptCooldown, CheckInterval: DefaultCheckInterval}
+}
+
+// ShouldPrompt reports whether the update dialog should be shown.
+func (p Policy) ShouldPrompt(state State, now time.Time) bool {
+	if !state.UpdateAvailable() {
+		return false
+	}
+	if state.IsSkipped() {
+		return false
+	}
+	if state.LastPromptUnixMs <= 0 {
+		return true
+	}
+	cooldown := p.PromptCooldown
+	if cooldown <= 0 {
+		cooldown = DefaultPromptCooldown
+	}
+	lastPrompt := time.UnixMilli(state.LastPromptUnixMs)
+	return now.Sub(lastPrompt) >= cooldown
+}
+
+// ShouldShowBanner reports whether the update banner should be visible.
+func (p Policy) ShouldShowBanner(state State) bool {
+	if !state.UpdateAvailable() {
+		return false
+	}
+	return !state.IsSkipped()
+}
+
+// ShouldCheck reports whether a periodic update check should run.
+func (p Policy) ShouldCheck(lastCheckUnixMs int64, now time.Time) bool {
+	interval := p.CheckInterval
+	if interval <= 0 {
+		interval = DefaultCheckInterval
+	}
+	if lastCheckUnixMs <= 0 {
+		return true
+	}
+	lastCheck := time.UnixMilli(lastCheckUnixMs)
+	return now.Sub(lastCheck) >= interval
+}

--- a/internal/update/state.go
+++ b/internal/update/state.go
@@ -1,0 +1,47 @@
+package update
+
+import "time"
+
+// State captures persisted update metadata.
+type State struct {
+	CurrentVersion   string  `json:"current_version"`
+	LatestVersion    string  `json:"latest_version,omitempty"`
+	SkippedVersion   string  `json:"skipped_version,omitempty"`
+	LastPromptUnixMs int64   `json:"last_prompt_unix_ms,omitempty"`
+	LastCheckUnixMs  int64   `json:"last_check_unix_ms,omitempty"`
+	Channel          Channel `json:"channel,omitempty"`
+}
+
+// UpdateAvailable reports whether a newer version exists.
+func (s State) UpdateAvailable() bool {
+	if IsDevelopmentVersion(s.CurrentVersion) {
+		return false
+	}
+	cmp, err := CompareVersions(s.CurrentVersion, s.LatestVersion)
+	if err != nil {
+		return false
+	}
+	return cmp < 0
+}
+
+// IsSkipped reports whether the latest version is skipped.
+func (s State) IsSkipped() bool {
+	if s.SkippedVersion == "" || s.LatestVersion == "" {
+		return false
+	}
+	return NormalizeVersion(s.SkippedVersion) == NormalizeVersion(s.LatestVersion)
+}
+
+func (s *State) MarkPrompted(now time.Time) {
+	if s == nil {
+		return
+	}
+	s.LastPromptUnixMs = now.UnixMilli()
+}
+
+func (s *State) MarkChecked(now time.Time) {
+	if s == nil {
+		return
+	}
+	s.LastCheckUnixMs = now.UnixMilli()
+}

--- a/internal/update/store.go
+++ b/internal/update/store.go
@@ -1,0 +1,131 @@
+package update
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+
+	"github.com/regenrek/peakypanes/internal/runenv"
+)
+
+var ErrStateDisabled = errors.New("update state disabled")
+
+// Store loads and saves update state.
+type Store interface {
+	Load(ctx context.Context) (State, error)
+	Save(ctx context.Context, state State) error
+}
+
+// FileStore persists update state to a JSON file.
+type FileStore struct {
+	Path string
+}
+
+// DefaultStatePath resolves the update state file path.
+func DefaultStatePath() (string, error) {
+	if runenv.FreshConfigEnabled() {
+		return "", ErrStateDisabled
+	}
+	if dir := runenv.ConfigDir(); dir != "" {
+		return filepath.Join(dir, "update-state.json"), nil
+	}
+	home, err := os.UserHomeDir()
+	if err != nil {
+		return "", err
+	}
+	return filepath.Join(home, ".config", "peakypanes", "update-state.json"), nil
+}
+
+// Load reads update state from disk.
+func (s FileStore) Load(ctx context.Context) (State, error) {
+	if ctx == nil {
+		ctx = context.Background()
+	}
+	if err := ctx.Err(); err != nil {
+		return State{}, err
+	}
+	path, err := cleanStatePath(s.Path)
+	if err != nil {
+		return State{}, err
+	}
+	data, err := os.ReadFile(path)
+	if err != nil {
+		if errors.Is(err, os.ErrNotExist) {
+			return State{}, nil
+		}
+		return State{}, fmt.Errorf("read update state: %w", err)
+	}
+	if err := ctx.Err(); err != nil {
+		return State{}, err
+	}
+	var state State
+	if err := json.Unmarshal(data, &state); err != nil {
+		return State{}, fmt.Errorf("parse update state: %w", err)
+	}
+	return state, nil
+}
+
+// Save writes update state to disk atomically.
+func (s FileStore) Save(ctx context.Context, state State) error {
+	if ctx == nil {
+		ctx = context.Background()
+	}
+	if err := ctx.Err(); err != nil {
+		return err
+	}
+	path, err := cleanStatePath(s.Path)
+	if err != nil {
+		return err
+	}
+	dir := filepath.Dir(path)
+	if dir == "." || dir == "" {
+		return fmt.Errorf("update state path missing directory")
+	}
+	if err := os.MkdirAll(dir, 0o700); err != nil {
+		return fmt.Errorf("create update state dir: %w", err)
+	}
+	payload, err := json.MarshalIndent(state, "", "  ")
+	if err != nil {
+		return fmt.Errorf("marshal update state: %w", err)
+	}
+	payload = append(payload, '\n')
+	if err := ctx.Err(); err != nil {
+		return err
+	}
+	tempFile, err := os.CreateTemp(dir, "update-state-*.json")
+	if err != nil {
+		return fmt.Errorf("create update state temp file: %w", err)
+	}
+	tempName := tempFile.Name()
+	defer func() {
+		_ = tempFile.Close()
+		_ = os.Remove(tempName)
+	}()
+	if _, err := tempFile.Write(payload); err != nil {
+		return fmt.Errorf("write update state temp file: %w", err)
+	}
+	if err := tempFile.Sync(); err != nil {
+		return fmt.Errorf("sync update state temp file: %w", err)
+	}
+	if err := tempFile.Close(); err != nil {
+		return fmt.Errorf("close update state temp file: %w", err)
+	}
+	if err := os.Rename(tempName, path); err != nil {
+		return fmt.Errorf("rename update state temp file: %w", err)
+	}
+	return nil
+}
+
+func cleanStatePath(path string) (string, error) {
+	if path == "" {
+		return "", ErrStateDisabled
+	}
+	cleaned := filepath.Clean(path)
+	if !filepath.IsAbs(cleaned) {
+		return "", fmt.Errorf("update state path must be absolute")
+	}
+	return cleaned, nil
+}

--- a/internal/update/update_test.go
+++ b/internal/update/update_test.go
@@ -1,0 +1,94 @@
+package update
+
+import (
+	"context"
+	"path/filepath"
+	"testing"
+	"time"
+)
+
+func TestCompareVersions(t *testing.T) {
+	cmp, err := CompareVersions("1.2.3", "1.2.4")
+	if err != nil {
+		t.Fatalf("CompareVersions error: %v", err)
+	}
+	if cmp >= 0 {
+		t.Fatalf("expected current < latest")
+	}
+
+	cmp, err = CompareVersions("v1.2.3", "1.2.3")
+	if err != nil {
+		t.Fatalf("CompareVersions error: %v", err)
+	}
+	if cmp != 0 {
+		t.Fatalf("expected versions equal")
+	}
+}
+
+func TestIsDevelopmentVersion(t *testing.T) {
+	cases := []struct {
+		value string
+		want  bool
+	}{
+		{"dev", true},
+		{"unknown", true},
+		{"v0.1.0-0.20251231235959-06c807842604", true},
+		{"1.2.3", false},
+	}
+	for _, c := range cases {
+		if got := IsDevelopmentVersion(c.value); got != c.want {
+			t.Fatalf("IsDevelopmentVersion(%q) = %v, want %v", c.value, got, c.want)
+		}
+	}
+}
+
+func TestStateUpdateAvailableAndSkip(t *testing.T) {
+	state := State{CurrentVersion: "1.0.0", LatestVersion: "1.1.0"}
+	if !state.UpdateAvailable() {
+		t.Fatalf("expected update available")
+	}
+	state.SkippedVersion = "1.1.0"
+	if !state.IsSkipped() {
+		t.Fatalf("expected update skipped")
+	}
+}
+
+func TestPolicyShouldPromptCooldown(t *testing.T) {
+	policy := DefaultPolicy()
+	now := time.Now()
+	state := State{CurrentVersion: "1.0.0", LatestVersion: "1.1.0"}
+	state.MarkPrompted(now)
+	if policy.ShouldPrompt(state, now.Add(1*time.Hour)) {
+		t.Fatalf("expected cooldown to suppress prompt")
+	}
+	if !policy.ShouldPrompt(state, now.Add(73*time.Hour)) {
+		t.Fatalf("expected prompt after cooldown")
+	}
+}
+
+func TestFileStoreSaveLoad(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "update-state.json")
+	store := FileStore{Path: path}
+	state := State{
+		CurrentVersion:   "1.0.0",
+		LatestVersion:    "1.2.0",
+		SkippedVersion:   "",
+		LastPromptUnixMs: 123,
+		LastCheckUnixMs:  456,
+		Channel:          ChannelNPMGlobal,
+	}
+	if err := store.Save(context.Background(), state); err != nil {
+		t.Fatalf("Save error: %v", err)
+	}
+	loaded, err := store.Load(context.Background())
+	if err != nil {
+		t.Fatalf("Load error: %v", err)
+	}
+	if loaded.CurrentVersion != state.CurrentVersion || loaded.LatestVersion != state.LatestVersion {
+		t.Fatalf("loaded state mismatch: %#v", loaded)
+	}
+	if loaded.Channel != state.Channel {
+		t.Fatalf("expected channel %q, got %q", state.Channel, loaded.Channel)
+	}
+}

--- a/internal/update/version.go
+++ b/internal/update/version.go
@@ -1,0 +1,57 @@
+package update
+
+import (
+	"regexp"
+	"strings"
+
+	"github.com/Masterminds/semver/v3"
+)
+
+var goInstallRegexp = regexp.MustCompile(`^v?\d+\.\d+\.\d+-\d+\.\d{14}-[0-9a-f]{12}$`)
+
+// NormalizeVersion trims whitespace and a leading "v".
+func NormalizeVersion(raw string) string {
+	trimmed := strings.TrimSpace(raw)
+	if trimmed == "" {
+		return ""
+	}
+	return strings.TrimPrefix(trimmed, "v")
+}
+
+// IsDevelopmentVersion reports whether the version should suppress update prompts.
+func IsDevelopmentVersion(raw string) bool {
+	value := strings.TrimSpace(raw)
+	if value == "" {
+		return true
+	}
+	lower := strings.ToLower(value)
+	switch lower {
+	case "dev", "devel", "unknown":
+		return true
+	}
+	if strings.Contains(lower, "dirty") {
+		return true
+	}
+	return goInstallRegexp.MatchString(value)
+}
+
+func parseSemver(raw string) (*semver.Version, error) {
+	normalized := NormalizeVersion(raw)
+	if normalized == "" {
+		return nil, semver.ErrInvalidSemVer
+	}
+	return semver.NewVersion(normalized)
+}
+
+// CompareVersions compares two semantic versions.
+func CompareVersions(current, latest string) (int, error) {
+	cur, err := parseSemver(current)
+	if err != nil {
+		return 0, err
+	}
+	lat, err := parseSemver(latest)
+	if err != nil {
+		return 0, err
+	}
+	return cur.Compare(lat), nil
+}


### PR DESCRIPTION
## Summary
- add npm registry update checks with persisted policy/state and installer commands
- integrate update banner, dialogs, progress, and restart flow in the TUI
- add updater tests for policy/state/semver and UI prompt behavior

## Testing
- ~/.codex/skills/go-local-health/scripts/go-local-health --scope ./...